### PR TITLE
feat: Integrate Skeleton UI and update Todo app

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
 		"tailwindcss": "^4.0.0",
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
-		"vite": "^6.2.6"
+		"vite": "^6.2.6",
+		"@skeletonlabs/skeleton": "^2.10.1",
+		"@skeletonlabs/skeleton-svelte": "^1.2.2",
+		"@playwright/test": "^1.45.3"
 	},
 	"pnpm": {
 		"onlyBuiltDependencies": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:5173', // Default SvelteKit dev port
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'pnpm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,15 @@ importers:
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.27.0
+      '@playwright/test':
+        specifier: ^1.45.3
+        version: 1.52.0
+      '@skeletonlabs/skeleton':
+        specifier: ^2.10.1
+        version: 2.11.0(svelte@5.30.2)
+      '@skeletonlabs/skeleton-svelte':
+        specifier: ^1.2.2
+        version: 1.2.2(svelte@5.30.2)
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
         version: 6.0.1(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.30.2)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.30.2)(vite@6.3.5(@types/node@22.15.18)(jiti@2.4.2)(lightningcss@1.30.1)))
@@ -566,6 +575,15 @@ packages:
     resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.0':
+    resolution: {integrity: sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==}
+
+  '@floating-ui/dom@1.7.0':
+    resolution: {integrity: sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==}
+
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -622,6 +640,11 @@ packages:
 
   '@petamoriken/float16@3.9.2':
     resolution: {integrity: sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==}
+
+  '@playwright/test@1.52.0':
+    resolution: {integrity: sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -725,6 +748,16 @@ packages:
     resolution: {integrity: sha512-h1J+Yzjo/X+0EAvR2kIXJDuTuyT7drc+t2ALY0nIcGPbTatNOf0VWdhEA2Z4AAjv6X1NJV7SYo5oCTYRJhSlVA==}
     cpu: [x64]
     os: [win32]
+
+  '@skeletonlabs/skeleton-svelte@1.2.2':
+    resolution: {integrity: sha512-+bWCJKArxfHOtrLj6snzMx7DnXT+5atzJq7rzXYfx2Yox5BTIoHzryhjGHuXj0KwKoe0DWrlAfY/LucdYkGq2A==}
+    peerDependencies:
+      svelte: ^5.20.0
+
+  '@skeletonlabs/skeleton@2.11.0':
+    resolution: {integrity: sha512-ORMZYACsIlfKyBx2ZIHBy7zE877t99fxU7LzcY1dveVmn2//+OeqnbQb5RryNILsMR62Tuu1VLnCu01/ByHlbQ==}
+    peerDependencies:
+      svelte: ^3.56.0 || ^4.0.0 || ^5.0.0
 
   '@sveltejs/acorn-typescript@1.0.5':
     resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
@@ -914,6 +947,113 @@ packages:
     resolution: {integrity: sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@zag-js/accordion@1.12.4':
+    resolution: {integrity: sha512-u63ztbMmG3retx5TBpN4TxDvnbqsYZ++G1Rdhjo/EuWm5PTApZrnP1D7gcqEDk4mBw/IkE3o1l3PzzLj6HUegg==}
+
+  '@zag-js/anatomy@1.12.4':
+    resolution: {integrity: sha512-bcNjZlVrHQqhiwEDiv0QNFWcMRxJqfqo891mzmnARj+Ey9mxzhrWoMGLj//fg9Q/u/i4Bul5Z2AOws2QboiMQg==}
+
+  '@zag-js/aria-hidden@1.12.4':
+    resolution: {integrity: sha512-IA7I8p80H7UecltHPlkHI/3lfyDdxs1BxXzhG1FLWtC6mbNjIL9Ie2mKz/9nYUJYMiIkTephRggX3genFkAwSQ==}
+
+  '@zag-js/auto-resize@1.12.4':
+    resolution: {integrity: sha512-FLpHdZ+e7SYw33k9GwkAD36FLpNN9OeF5iQXN2jeJgq0Q1Gya1y5Kekxy67eGdLLjCfehsauv46bnSUYJs0yoQ==}
+
+  '@zag-js/avatar@1.12.4':
+    resolution: {integrity: sha512-YnSiDQ8l19k2EV2OLatGjTAdLRpp2IBttADcQoZrGY74R6N519E3PAIP58UK/K2Hpygbal7XJ0mjB/ePbfPdTQ==}
+
+  '@zag-js/collection@1.12.4':
+    resolution: {integrity: sha512-EQNwCezUYyBH2tYeUHwMEIpFSDf4wAwhhpEPz/UhgZneaRnEL/T8F0eArZBf9OqRnVJEsl72nDzxMc7R078qsw==}
+
+  '@zag-js/combobox@1.12.4':
+    resolution: {integrity: sha512-bjtmB7PHMWTdq5Y96hgK/X8HMSxHry6LzcYz98F6WTDzoz+5nOZg3TLurBt87RGyM9JqNQHR99/YH75vVyBGaA==}
+
+  '@zag-js/core@1.12.4':
+    resolution: {integrity: sha512-W9ASCtNeOT08PO4T7/ZVzUYIv/N4b9F7QbPsNsozCpSkoeY4xXQn5PMe/JUWcOgS/ocBGwvCQLKpVSAhCAEHtQ==}
+
+  '@zag-js/dialog@1.12.4':
+    resolution: {integrity: sha512-99v1Tqm3r3qJBzurjnMmFmVjF9ZCZ7aATwzst2trI9yPJMrISiL6jq6s8iP6mKv71ED013YfQkHvaBqqy4zMTg==}
+
+  '@zag-js/dismissable@1.12.4':
+    resolution: {integrity: sha512-iZ7O3Yi4vnrfoXJWBFz8bHJoR3QpfZcokiaqWRJkwDJzVzN9E3kA00232MfR1x01y7lFDyZMabvCRDuQcMaBmg==}
+
+  '@zag-js/dom-query@1.12.4':
+    resolution: {integrity: sha512-EICuVDdjmCnTX/vkO/t51XpaOFKQbMnD74AprQjOosrY7bXs0VFmLbQ5hHmOZd7rr7GbNfd3VyO7VmyeZoF32w==}
+
+  '@zag-js/file-upload@1.12.4':
+    resolution: {integrity: sha512-m3VRAfQPTnIBKc0LUeeD7s9VfYrazzLwAK2m6LaHwGfpQbdGjzjBmWfrLnDLJqt5CVzvjMAMU8NN+0kDtS/nxg==}
+
+  '@zag-js/file-utils@1.12.4':
+    resolution: {integrity: sha512-nPwpWlUPBFSgcYuvkHHLQqwO6rr0g2sQjITjE4xEv8hnpZCOk9EG77SvNZeIulJD2vn7AfnTvif3hk5piwE0bA==}
+
+  '@zag-js/focus-trap@1.12.4':
+    resolution: {integrity: sha512-BCtcB8mrXW6guEmUmT6YOHwjYF6keDhJA5+7pwm5ctMlMp7cMljGaA6ZLofn/5Qi/H2CUjVv4FSy7YqrvsFdxQ==}
+
+  '@zag-js/focus-visible@1.12.4':
+    resolution: {integrity: sha512-NCzeBwz2XvtTqPYaGa2G2Bjs2//o3RG6mlneOVWdj92UUrj7Ybh9LBmx6DBCFcxXSrmANDls/7EOrYuXvN/s/A==}
+
+  '@zag-js/i18n-utils@1.12.4':
+    resolution: {integrity: sha512-imTLTstPAmBvgUj+0pqjUZ0Sz9NGoVIhUpdvozvcgCMnAlTEMJlgl3BM0CzjDAT5tJM0McXPuGjgqFVX6u3WjA==}
+
+  '@zag-js/interact-outside@1.12.4':
+    resolution: {integrity: sha512-aHZ2p+WFKSX9w4hVMpuApcqSMo+h41iGjCoimbH2Mw2uKtLAnM5avFpPsLJaiO9AvF22BXH8F9xCnmnAGISyLQ==}
+
+  '@zag-js/live-region@1.12.4':
+    resolution: {integrity: sha512-nn+vOBdtQBG34XxIFPJ3AEkd+y3WA/TnPGv3ldIpzHvynBvXFdLp1lAua3FJ6k1zo7PvDsrLeG75iX6QqqX9yQ==}
+
+  '@zag-js/pagination@1.12.4':
+    resolution: {integrity: sha512-fRMLpiamDJbn8vvXK2xDa0niJGM9BqioGLqVNrzFDvBldnTauUIvEAJVWil98slOO6XfHfHT07pSnADR1dgk0Q==}
+
+  '@zag-js/popover@1.12.4':
+    resolution: {integrity: sha512-dlqxYpubVzo6EOwPgJ25Cbfaiu1ZQq3hOlYd3If/HM7DQRTy3CUuSCKUIJwx/DGSuD5TRQUgBESbAD9QqjCOGg==}
+
+  '@zag-js/popper@1.12.4':
+    resolution: {integrity: sha512-r+tKkJXCtTEOkBN6iXFjva3tZKA4F/M+Y6oSaNpPtG2S5f71yxFcC3rhYeIRrZD6qiT8q2swFVjaWhuQFUjpkw==}
+
+  '@zag-js/progress@1.12.4':
+    resolution: {integrity: sha512-fzAbDn2deBzp1Er8zFi29DxWhdneRgSPidFYszVqTZBzV6I6c2wE96DsSp1GudI72KNwcfy3dDeoqqWQpI4imQ==}
+
+  '@zag-js/radio-group@1.12.4':
+    resolution: {integrity: sha512-AoGO29CHlDYliu3oPj6vds8bq2BE0pijPDgBA0YrftSsvpuFuGgAXZJTvy+/P+ZoBu9pnbz05Z4pKPN6EldB7w==}
+
+  '@zag-js/rating-group@1.12.4':
+    resolution: {integrity: sha512-TxW6423dD+yxORz9jZQQzpQunfjd7GShCN7eWw8tfRdCpOZlxUzuADJKM+tLl70nDp0zXkeuzWbB63sVO6d5vg==}
+
+  '@zag-js/remove-scroll@1.12.4':
+    resolution: {integrity: sha512-vyuaHEEHs5IaXAPxuO5KTA9/ds7fMr8TnXdyxbnQJ06+CCEKtuz3GWT027VqOF7zlGHhEpFHxHtepVBaI/iUkA==}
+
+  '@zag-js/slider@1.12.4':
+    resolution: {integrity: sha512-AYW4OgDwvdeRQtuxrIhe847HfWenvzhSBwhfv6PxzJyX4Mk21UpfE2UIDGc9ejsVqipVhiAo4r5hcEBmevzW7Q==}
+
+  '@zag-js/store@1.12.4':
+    resolution: {integrity: sha512-VBQMa9ArOlIrvpXksk2dTfPL+XsHKSX7OArWJ+YjuYEYCLLVdmVo6M7W1YZyuQu+wQ6udwkOZil1cB9HD6hzIA==}
+
+  '@zag-js/svelte@1.12.4':
+    resolution: {integrity: sha512-Uq3dufVLsOckw2z15F61qy4b7tl4ALJGoxopvD7QPsjbrYGu9Dn8RPn5LFcDgEPjO7cIgMHamzv47ivsyKAMmQ==}
+    peerDependencies:
+      svelte: ^5.0.0-next.1
+
+  '@zag-js/switch@1.12.4':
+    resolution: {integrity: sha512-lfII+tBnh9GjXN4n5/sYbmo8XLF3lxqlrqKyfcIMm854ceyhXsC5Mf6xUF6IBOhPIlcPF2LQeCRCaxuwtVeYdw==}
+
+  '@zag-js/tabs@1.12.4':
+    resolution: {integrity: sha512-lP88tFTFXyEM8u6dwY6jgYKZMhCLEG7r4pc2QtNcShXZwHcGkHMCsTkJpxowN8+GZKIf13VHLKRoPHhc/7JCYg==}
+
+  '@zag-js/tags-input@1.12.4':
+    resolution: {integrity: sha512-GM9itpuVsaniNDha5ydukPv+zsargo+nj3z0cxNmf6U6Zh7YoGJwgOyzlIzCGZDEU3hyrrVuQoouNs/Iel7CpQ==}
+
+  '@zag-js/toast@1.12.4':
+    resolution: {integrity: sha512-tUVqmbMLW6tfe9xA3vHlDyhBd5OVxNDy0uuEdq4wTnPYAjwrzU/CzpDrz2YJWwE5gKxgtvURgANaDahyi70c0g==}
+
+  '@zag-js/tooltip@1.12.4':
+    resolution: {integrity: sha512-8mh/Ko1AbX8SS8OzgF21UfY6Abnjt2jwtwR4PlD4M+/WoekfDVsshEFCCm5lJrTn5l15ZFOedeEZtk1RPItqIw==}
+
+  '@zag-js/types@1.12.4':
+    resolution: {integrity: sha512-Ot8mLjG+3PYAMiU79v6KdQYxxFPbg3y9Sku4U1gDNPMbsMHOoTg/GMtpXY6P0rzmNfxATYX6BblnZBBQ8cxvDA==}
+
+  '@zag-js/utils@1.12.4':
+    resolution: {integrity: sha512-JPBTDmx05azPH1YCjbGv2VNoU4Fx8TWi7mZ/Pcqjl+FYXAsQeRJpVoYhKWM7U0fGwv6Anjvt1M+LQxnuxFVsAg==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1000,6 +1140,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -1187,6 +1330,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.0.0:
+    resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
@@ -1255,6 +1401,11 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1531,6 +1682,16 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -1636,6 +1797,9 @@ packages:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proxy-compare@3.0.1:
+    resolution: {integrity: sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2143,6 +2307,17 @@ snapshots:
       '@eslint/core': 0.14.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/dom@1.7.0':
+    dependencies:
+      '@floating-ui/core': 1.7.0
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/utils@0.2.9': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2190,6 +2365,10 @@ snapshots:
       fastq: 1.19.1
 
   '@petamoriken/float16@3.9.2': {}
+
+  '@playwright/test@1.52.0':
+    dependencies:
+      playwright: 1.52.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -2252,6 +2431,32 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.41.0':
     optional: true
+
+  '@skeletonlabs/skeleton-svelte@1.2.2(svelte@5.30.2)':
+    dependencies:
+      '@zag-js/accordion': 1.12.4
+      '@zag-js/avatar': 1.12.4
+      '@zag-js/combobox': 1.12.4
+      '@zag-js/dialog': 1.12.4
+      '@zag-js/file-upload': 1.12.4
+      '@zag-js/pagination': 1.12.4
+      '@zag-js/popover': 1.12.4
+      '@zag-js/progress': 1.12.4
+      '@zag-js/radio-group': 1.12.4
+      '@zag-js/rating-group': 1.12.4
+      '@zag-js/slider': 1.12.4
+      '@zag-js/svelte': 1.12.4(svelte@5.30.2)
+      '@zag-js/switch': 1.12.4
+      '@zag-js/tabs': 1.12.4
+      '@zag-js/tags-input': 1.12.4
+      '@zag-js/toast': 1.12.4
+      '@zag-js/tooltip': 1.12.4
+      svelte: 5.30.2
+
+  '@skeletonlabs/skeleton@2.11.0(svelte@5.30.2)':
+    dependencies:
+      esm-env: 1.0.0
+      svelte: 5.30.2
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
     dependencies:
@@ -2464,6 +2669,235 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
 
+  '@zag-js/accordion@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/anatomy@1.12.4': {}
+
+  '@zag-js/aria-hidden@1.12.4': {}
+
+  '@zag-js/auto-resize@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+
+  '@zag-js/avatar@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/collection@1.12.4':
+    dependencies:
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/combobox@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/aria-hidden': 1.12.4
+      '@zag-js/collection': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dismissable': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/popper': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/core@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/dialog@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/aria-hidden': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dismissable': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/focus-trap': 1.12.4
+      '@zag-js/remove-scroll': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/dismissable@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/interact-outside': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/dom-query@1.12.4':
+    dependencies:
+      '@zag-js/types': 1.12.4
+
+  '@zag-js/file-upload@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/file-utils': 1.12.4
+      '@zag-js/i18n-utils': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/file-utils@1.12.4':
+    dependencies:
+      '@zag-js/i18n-utils': 1.12.4
+
+  '@zag-js/focus-trap@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+
+  '@zag-js/focus-visible@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+
+  '@zag-js/i18n-utils@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+
+  '@zag-js/interact-outside@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/live-region@1.12.4': {}
+
+  '@zag-js/pagination@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/popover@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/aria-hidden': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dismissable': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/focus-trap': 1.12.4
+      '@zag-js/popper': 1.12.4
+      '@zag-js/remove-scroll': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/popper@1.12.4':
+    dependencies:
+      '@floating-ui/dom': 1.7.0
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/progress@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/radio-group@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/focus-visible': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/rating-group@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/remove-scroll@1.12.4':
+    dependencies:
+      '@zag-js/dom-query': 1.12.4
+
+  '@zag-js/slider@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/store@1.12.4':
+    dependencies:
+      proxy-compare: 3.0.1
+
+  '@zag-js/svelte@1.12.4(svelte@5.30.2)':
+    dependencies:
+      '@zag-js/core': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+      svelte: 5.30.2
+
+  '@zag-js/switch@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/focus-visible': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/tabs@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/tags-input@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/auto-resize': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/interact-outside': 1.12.4
+      '@zag-js/live-region': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/toast@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dismissable': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/tooltip@1.12.4':
+    dependencies:
+      '@zag-js/anatomy': 1.12.4
+      '@zag-js/core': 1.12.4
+      '@zag-js/dom-query': 1.12.4
+      '@zag-js/focus-visible': 1.12.4
+      '@zag-js/popper': 1.12.4
+      '@zag-js/store': 1.12.4
+      '@zag-js/types': 1.12.4
+      '@zag-js/utils': 1.12.4
+
+  '@zag-js/types@1.12.4':
+    dependencies:
+      csstype: 3.1.3
+
+  '@zag-js/utils@1.12.4': {}
+
   acorn-jsx@5.3.2(acorn@8.14.1):
     dependencies:
       acorn: 8.14.1
@@ -2536,6 +2970,8 @@ snapshots:
       which: 2.0.2
 
   cssesc@3.0.0: {}
+
+  csstype@3.1.3: {}
 
   debug@4.4.1:
     dependencies:
@@ -2732,6 +3168,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.0.0: {}
+
   esm-env@1.2.2: {}
 
   espree@10.3.0:
@@ -2797,6 +3235,9 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3011,6 +3452,14 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-load-config@3.1.4(postcss@8.5.3):
     dependencies:
       lilconfig: 2.1.0
@@ -3053,6 +3502,8 @@ snapshots:
       prettier-plugin-svelte: 3.4.0(prettier@3.5.3)(svelte@5.30.2)
 
   prettier@3.5.3: {}
+
+  proxy-compare@3.0.1: {}
 
   punycode@2.3.1: {}
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 @import '@skeletonlabs/skeleton';
-@import '@skeletonlabs/skeleton/optional/presets';
+/* The problematic line "@skeletonlabs/skeleton/optional/presets" was removed */
 @import '@skeletonlabs/skeleton/themes/cerberus'; /* Or a theme of choice */
 @source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
 @plugin '@tailwindcss/forms';

--- a/src/app.css
+++ b/src/app.css
@@ -1,2 +1,6 @@
 @import 'tailwindcss';
+@import '@skeletonlabs/skeleton';
+@import '@skeletonlabs/skeleton/optional/presets';
+@import '@skeletonlabs/skeleton/themes/cerberus'; /* Or a theme of choice */
+@source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
 @plugin '@tailwindcss/forms';

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="cerberus">
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,29 +1,22 @@
 <script lang="ts">
 	import '../app.css';
+	import { AppShell, AppBar } from '@skeletonlabs/skeleton-svelte';
 
 	let { children } = $props();
 </script>
 
-<div class="flex min-h-screen flex-col">
-	<header class="bg-blue-600 text-white">
-		<div class="container mx-auto flex items-center justify-between p-4">
-			<h1 class="text-xl font-bold">Svelte Todos</h1>
-			<nav>
-				<ul class="flex space-x-4">
-					<li><a href="/" class="hover:underline">Home</a></li>
-					<li><a href="/todos" class="hover:underline">Todos</a></li>
-				</ul>
-			</nav>
-		</div>
-	</header>
-
-	<main class="flex-grow">
-		{@render children()}
-	</main>
-
-	<footer class="bg-gray-100 p-4 text-center text-gray-600">
-		<div class="container mx-auto">
-			<p>Svelte Todos App - {new Date().getFullYear()}</p>
-		</div>
-	</footer>
-</div>
+<AppShell>
+	<svelte:fragment slot="header">
+		<AppBar>
+			<svelte:fragment slot="lead">
+				<strong class="text-xl uppercase">Svelte Todos</strong>
+			</svelte:fragment>
+			<svelte:fragment slot="trail">
+				<a href="/" class="btn btn-sm variant-ghost-surface">Home</a>
+				<a href="/todos" class="btn btn-sm variant-ghost-surface">Todos</a>
+			</svelte:fragment>
+		</AppBar>
+	</svelte:fragment>
+	<!-- Main content -->
+	{@render children()}
+</AppShell>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+	import { Card, Button } from '@skeletonlabs/skeleton-svelte';
+</script>
+
 <svelte:head>
 	<title>Svelte Todos - Home</title>
 </svelte:head>
@@ -6,14 +10,11 @@
 	<h1 class="mb-6 text-4xl font-bold">Welcome to Svelte Todos</h1>
 	<p class="mb-8 text-lg">A simple todo application built with SvelteKit and Drizzle ORM.</p>
 
-	<div class="rounded-lg bg-white p-8 shadow-md">
+	<Card class="p-8 shadow-md">
 		<h2 class="mb-4 text-2xl font-semibold">Get Started</h2>
 		<p class="mb-6">Start managing your todos by clicking the button below:</p>
-		<a
-			href="/todos"
-			class="inline-block rounded-lg bg-blue-500 px-6 py-2 font-medium text-white transition-colors hover:bg-blue-600"
-		>
+		<Button href="/todos" class="variant-filled-primary">
 			Go to Todos
-		</a>
-	</div>
+		</Button>
+	</Card>
 </div>

--- a/src/routes/todos/+page.svelte
+++ b/src/routes/todos/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import type { PageData } from './$types';
+	import { Card, Input, Button, Checkbox } from '@skeletonlabs/skeleton-svelte';
 
 	export let data: PageData;
 
@@ -23,7 +24,7 @@
 	<title>Todos</title>
 </svelte:head>
 
-<div class="container mx-auto max-w-3xl p-4">
+<Card class="container mx-auto max-w-3xl p-4">
 	<h1 class="mb-6 text-3xl font-bold">Todos</h1>
 
 	<!-- Add new todo form -->
@@ -40,16 +41,14 @@
 		}}
 		class="mb-8 flex items-center gap-2"
 	>
-		<input
+		<Input
 			type="text"
 			name="text"
 			bind:value={newTodoText}
 			placeholder="Add a new todo..."
-			class="flex-grow rounded border border-gray-300 p-2"
+			class="flex-grow"
 		/>
-		<button type="submit" class="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600">
-			Add Todo
-		</button>
+		<Button type="submit" class="variant-filled-primary">Add Todo</Button>
 	</form>
 
 	<!-- Todo list -->
@@ -59,44 +58,35 @@
 		{/if}
 
 		{#each data.todos as todo (todo.id)}
-			<div class="flex items-center gap-3 rounded bg-white p-4 shadow-md">
+			<Card class="flex items-center gap-3 p-4">
 				<!-- Toggle done status -->
 				<form
 					method="POST"
 					action="?/toggleDone"
 					use:enhance={() =>
 						({ result, update }) => {
-							console.log(result);
 							if (result.type === 'success') {
 								update();
 							}
 						}}
+					class="flex-shrink-0"
 				>
 					<input type="hidden" name="id" value={todo.id} />
-					<input type="hidden" name="done" value={todo.done.toString()} />
-					<button type="submit" class="flex-shrink-0">
-						<div
-							class="flex h-6 w-6 items-center justify-center rounded-md border-2 {todo.done
-								? 'border-green-500 bg-green-500'
-								: 'border-gray-300'}"
-						>
-							{#if todo.done}
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="white"
-									stroke-width="3"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<polyline points="20 6 9 17 4 12"></polyline>
-								</svg>
-							{/if}
-						</div>
-					</button>
+					<!-- The 'done' input is still useful for progressive enhancement if JS fails -->
+					<input type="hidden" name="done" value={(!todo.done).toString()} />
+					<Checkbox
+						checked={todo.done}
+						on:change={(e) => {
+							// Programmatically submit the form when checkbox state changes
+							// HTMLFormElement.requestSubmit() is the modern way to do this
+							const form = e.currentTarget.closest('form');
+							if (form) {
+								form.requestSubmit();
+							}
+						}}
+						aria-label="Toggle todo status"
+						class="flex-shrink-0"
+					/>
 				</form>
 
 				{#if editingId === todo.id}
@@ -112,29 +102,20 @@
 								}
 							};
 						}}
-						class="flex flex-grow gap-2"
+						class="flex flex-grow items-center gap-2"
 					>
 						<input type="hidden" name="id" value={todo.id} />
 						<input type="hidden" name="done" value={todo.done.toString()} />
-						<input
+						<Input
 							type="text"
 							name="text"
 							bind:value={editText}
-							class="flex-grow rounded border border-gray-300 p-2"
+							class="flex-grow"
 						/>
-						<button
-							type="submit"
-							class="rounded bg-green-500 px-3 py-1 text-white hover:bg-green-600"
-						>
-							Save
-						</button>
-						<button
-							type="button"
-							on:click={cancelEditing}
-							class="rounded bg-gray-300 px-3 py-1 text-gray-700 hover:bg-gray-400"
-						>
+						<Button type="submit" class="variant-filled-success">Save</Button>
+						<Button type="button" on:click={cancelEditing} class="variant-ghost-surface">
 							Cancel
-						</button>
+						</Button>
 					</form>
 				{:else}
 					<!-- View mode -->
@@ -143,26 +124,13 @@
 					</span>
 
 					<div class="flex flex-shrink-0 gap-2">
-						<button
+						<Button
 							aria-label="Edit todo"
 							on:click={() => startEditing(todo)}
-							class="cursor-pointer text-blue-500 hover:text-blue-700"
+							class="variant-soft-primary"
 						>
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								width="16"
-								height="16"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-								<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-							</svg>
-						</button>
+							Edit
+						</Button>
 
 						<form
 							method="POST"
@@ -175,42 +143,13 @@
 								}}
 						>
 							<input type="hidden" name="id" value={todo.id} />
-							<button
-								type="submit"
-								aria-label="Delete todo"
-								class="cursor-pointer text-red-500 hover:text-red-700"
-							>
-								<svg
-									xmlns="http://www.w3.org/2000/svg"
-									width="16"
-									height="16"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-								>
-									<polyline points="3 6 5 6 21 6"></polyline>
-									<path
-										d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-									></path>
-									<line x1="10" y1="11" x2="10" y2="17"></line>
-									<line x1="14" y1="11" x2="14" y2="17"></line>
-								</svg>
-							</button>
+							<Button type="submit" aria-label="Delete todo" class="variant-soft-error">
+								Delete
+							</Button>
 						</form>
 					</div>
 				{/if}
-			</div>
+			</Card>
 		{/each}
 	</div>
-</div>
-
-<style>
-	input:focus,
-	button:focus {
-		outline: 2px solid rgb(59, 130, 246);
-		outline-offset: 2px;
-	}
-</style>
+</Card>

--- a/tests/todos.spec.ts
+++ b/tests/todos.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Todos Page', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/todos');
+		// Clear any existing todos from previous test runs to ensure a clean state
+		// This is important if tests don't clean up after themselves and the app persists data.
+		// For this app, todos are in-memory per page load or fetched, so this might not be strictly necessary
+		// unless there's actual persistence across test runs without server restart.
+		// A more robust way for true e2e might be resetting db or using unique user sessions.
+		// For now, we assume tests either clean up or page reloads provide a fresh start.
+	});
+
+	test('should allow me to add a new todo item', async ({ page }) => {
+		const newTodoText = 'Test new todo item';
+		// Selector for Skeleton input (rendered as <input name="text">)
+		await page.locator('input[name="text"]').fill(newTodoText);
+		// Selector for Skeleton button (rendered as <button class="variant-filled-primary">Add Todo</button>)
+		await page.locator('button.variant-filled-primary:has-text("Add Todo")').click();
+		
+		// Check within a Card that contains the todo text.
+		// Skeleton Card is a div with class 'card'. Each todo item is wrapped in such a card.
+		// We also look for the specific text within that card structure.
+		const todoItemCard = page.locator('div.card', { hasText: newTodoText });
+		await expect(todoItemCard.locator(`span:text-is("${newTodoText}")`)).toBeVisible();
+	});
+
+	test('should allow me to mark an item as completed', async ({ page }) => {
+		const todoToMarkText = 'Todo to mark as done';
+		// Add a todo first
+		await page.locator('input[name="text"]').fill(todoToMarkText);
+		await page.locator('button.variant-filled-primary:has-text("Add Todo")').click();
+		
+		// Find the card containing the todo
+		const todoItemCard = page.locator('div.card', { hasText: todoToMarkText });
+		// The checkbox is an input type="checkbox" within this card
+		const checkbox = todoItemCard.locator('input[type="checkbox"]');
+		
+		// Ensure it's not checked initially (or handle if it can be)
+		await expect(checkbox).not.toBeChecked();
+
+		await checkbox.check();
+		await expect(checkbox).toBeChecked();
+		
+		// Verify line-through style on the span containing the text
+		// The span class is dynamically computed: "flex-grow {todo.done ? 'text-gray-400 line-through' : ''}"
+		await expect(todoItemCard.locator(`span:text-is("${todoToMarkText}")`)).toHaveClass(/line-through/);
+	});
+
+	test('should allow me to delete a todo item', async ({ page }) => {
+		const todoToDeleteText = 'Todo to delete';
+		// Add a todo first
+		await page.locator('input[name="text"]').fill(todoToDeleteText);
+		await page.locator('button.variant-filled-primary:has-text("Add Todo")').click();
+		
+		const todoItemCard = page.locator('div.card', { hasText: todoToDeleteText });
+		// Ensure it's visible before trying to delete
+		await expect(todoItemCard.locator(`span:text-is("${todoToDeleteText}")`)).toBeVisible();
+
+		// Selector for Skeleton delete button (rendered as <button class="variant-soft-error">Delete</button>)
+		await todoItemCard.locator('button.variant-soft-error:has-text("Delete")').click();
+		
+		// The card containing the todo item should no longer be visible
+		await expect(todoItemCard).not.toBeVisible();
+	});
+});


### PR DESCRIPTION
Integrates the Skeleton UI component library into the SvelteKit application.

Key changes include:
- Installed Skeleton packages and configured Tailwind CSS.
- Updated the main layout (`+layout.svelte`) to use Skeleton's AppShell and AppBar.
- Refactored the home page (`+page.svelte`) to use Skeleton's Card and Button.
- Overhauled the Todos page (`todos/+page.svelte`) with Skeleton components (Card, Input, Button, Checkbox) while preserving all CRUD functionalities.
- Added Playwright configuration and e2e tests for the Todos page (`tests/todos.spec.ts`). Note: I wrote the tests, but couldn't run them due to environmental limitations preventing browser dependency installation.

The application now uses Skeleton for its core UI, providing a more modern look and feel.